### PR TITLE
Fixed path in NPM_STATIC_FILES_PREFIX in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Want to use npm modules in your django project without vendoring them? django-np
 
  * `NPM_ROOT_PATH`: *absolute* path to the npm "root" directory - this is where npm will look for your `package.json`, put your `node_modules` folder and look for a `.npmrc` file
  * `NPM_EXECUTABLE_PATH`: (optional) defaults to wherever `npm` is on your PATH.  If you specify this, you can override the path to the `npm` executable.  This is also an *absolute path*.
- * `NPM_STATIC_FILES_PREFIX`: (optional) Your npm files will end up under this path inside static.  I usually use something like 'js/lib' (so your files will be in /static/js/lib/react.js for example) but you can leave it blank and they will just end up in the root.
+ * `NPM_STATIC_FILES_PREFIX`: (optional) Your npm files will end up under this path inside static.  I usually use something like ` os.path.join('js', 'lib')` (so your files will be in /static/js/lib/react.js for example) but you can leave it blank and they will just end up in the root.
  * `NPM_FILE_PATTERNS`: (optional) By default, django-npm will expose all files in `node_modules` to Django as staticfiles.  You may not want *all* of them to be exposed.  You can pick specific files by adding some additional configuration:
 
     ```python


### PR DESCRIPTION
Fixed problem with path in NPM_STATIC_FILES_PREFIX on Windows when fallowing README ( #5 )