### PR TITLE
Fixed setup.py to make management command work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author='Kevin McCarthy',
     author_email='me@kevinmccarthy.org',
     license='MIT',
+    include_package_data=True,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Fixed the error:

```
$ ./manage.py npm_install
Unknown command: 'npm_install'
Type 'manage.py help' for usage.

```