### PR TITLE
Support wildcards in directory components

### DIFF
--- a/npm/finders.py
+++ b/npm/finders.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+from fnmatch import fnmatch
 
 from django.contrib.staticfiles import utils as django_utils
 from django.contrib.staticfiles.finders import FileSystemFinder
@@ -36,8 +37,19 @@ def flatten_patterns(patterns):
     ]
 
 
+def fnmatch_sub(directory, pattern):
+    """
+    Match a directory against a potentially longer pattern containing
+    wildcards in the path components. fnmatch does the globbing, but there
+    appears to be no built-in way to match only the beginning of a pattern.
+    """
+    length = len(directory.split(os.sep))
+    components = pattern.split(os.sep)[:length]
+    return fnmatch(directory, os.sep.join(components))
+
+
 def may_contain_match(directory, patterns):
-    return any(pattern.startswith(directory) for pattern in patterns)
+    return any(fnmatch_sub(directory, pattern) for pattern in patterns)
 
 
 def get_files(storage, match_patterns='*', ignore_patterns=None, location=''):

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -47,6 +47,11 @@ def test_finder_with_patterns_in_subdirectory(npm_dir):
         f = NpmFinder()
         assert f.find('lib/mocha/mocha.js')
 
+def test_finder_with_patterns_in_directory_component(npm_dir):
+    with override_settings(NPM_STATIC_FILES_PREFIX='lib', NPM_FILE_PATTERNS={'mocha': ['*/*js']}):
+        f = NpmFinder()
+        assert f.find('lib/mocha/lib/test.js')
+
 def test_no_matching_paths_returns_empty_list(npm_dir):
     with override_settings(NPM_FILE_PATTERNS={'foo': ['bar']}):
         f = NpmFinder()


### PR DESCRIPTION
We found django-npm to be super useful, unfortunately using wildcards currently only works for files and not for path components because the generator tests with `directory.startswith(pattern)`. With minor path mangling and `fnmatch` this should then also support cases like this:

```
NPM_FILE_PATTERNS = {
    'bootswatch': [
        '*/bootstrap.min.css'
    ]
```