### PR TITLE
Add compatibility with Django 5.2

### DIFF
--- a/npm/finders.py
+++ b/npm/finders.py
@@ -92,11 +92,11 @@ class NpmFinder(FileSystemFinder):
         filesystem_storage.prefix = self.locations[0][0]
         self.storages[self.locations[0][1]] = filesystem_storage
 
-    def find(self, path, all=False):
+    def find(self, path, **kwargs): # TODO switch to `find_all=False` when Django<5.2 is dropped
         relpath = os.path.relpath(path, self.destination)
         if not django_utils.matches_patterns(relpath, self.match_patterns):
             return []
-        return super(NpmFinder, self).find(path, all=all)
+        return super(NpmFinder, self).find(path, **kwargs)
 
     def list(self, ignore_patterns=None):  # TODO should be configurable, add setting
         """List all files in all locations."""

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-Django==1.9
-py==1.4.31
-pytest==2.8.4
-wheel==0.24.0
+Django==5.2
+py==1.11.0
+pytest==8.3.5
+wheel==0.45.1

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.12',
     ],
 
     keywords='django npm staticfiles',


### PR DESCRIPTION
Django 5.2 renames the `all` keyword argument of the `find()` method to `find_all`.
Since this implementation only passes the argument to `super().find()`, for now I just
take any keyword argument and pass them unchanged to the `super` implementation.
This makes it compatible with all versions of Django.